### PR TITLE
case statement syntax change

### DIFF
--- a/lib/robust_excel_ole/book.rb
+++ b/lib/robust_excel_ole/book.rb
@@ -713,9 +713,9 @@ module RobustExcelOle
         dirname, basename = File.split(file)
         file_format =
           case File.extname(basename)
-            when '.xls' : RobustExcelOle::XlExcel8
-            when '.xlsx': RobustExcelOle::XlOpenXMLWorkbook
-            when '.xlsm': RobustExcelOle::XlOpenXMLWorkbookMacroEnabled
+            when '.xls' ; RobustExcelOle::XlExcel8
+            when '.xlsx'; RobustExcelOle::XlOpenXMLWorkbook
+            when '.xlsm'; RobustExcelOle::XlOpenXMLWorkbookMacroEnabled
           end
         @ole_workbook.SaveAs(General::absolute_path(file), file_format)
         bookstore.store(self)


### PR DESCRIPTION
the case statement no longer allows :  to separate when from result in 1.9

The syntax that was deprecated was when x: ..., with a colon, to avoid collision with the new hash literal syntax (eg: when key: value then :result)