### PR TITLE
Make this test indepenent of data ordering 

### DIFF
--- a/spec/excel_spec.rb
+++ b/spec/excel_spec.rb
@@ -998,29 +998,20 @@ module RobustExcelOle
 
       it "should return two unsaved books" do
         book = Book.open(@simple_file)
-        sheet = book.sheet(1)
-        sheet[1,1] = sheet[1,1].value == "foo" ? "bar" : "foo"
         book2 = Book.open(@another_simple_file, :force_excel => :new)
-        sheet2 = book2.sheet(1)
-        sheet2[1,1] = sheet2[1,1].value == "foo" ? "bar" : "foo"
+        open_books = [book, book2]
+        begin 
+          open_books.each do |wb|
+            sheet = wb.sheet(1)
+            sheet[1,1] = (sheet[1,1].value == "foo") ? "bar" : "foo"
+          end 
         #Excel.unsaved_known_workbooks.should == [[book.ole_workbook], [book2.ole_workbook]]
-        unsaved_known_wbs = Excel.unsaved_known_workbooks
-        unsaved_known_wbs.size.should == 2
-        ole_wb_list1, ole_wb_list2 = unsaved_known_wbs
-        ole_wb_list1.each do |ole_wb_list|
-          ole_wb_list1.size.should == 1
-          ole_wb_list1.each do |ole_workbook|
-            ole_workbook.Fullname.tr('\\','/').should == @simple_file  
-          end
+          unsaved_known_wbs = Excel.unsaved_known_workbooks
+          unsaved_known_wbs.size.should == 2
+          unsaved_known_wbs.flatten.map{|ole_wb| ole_wb.Fullname.tr('\\','/') }.sort.should == open_books.map{|b| b.filename}.sort
+        ensure
+          open_books.each {|wb| wb.close(:if_unsaved => :forget)}
         end
-        ole_wb_list2.each do |ole_wb_list|
-          ole_wb_list2.size.should == 1
-          ole_wb_list2.each do |ole_workbook|
-            ole_workbook.Fullname.tr('\\','/').should == @another_simple_file  
-          end
-        end
-        book2.close(:if_unsaved => :forget)
-        book.close(:if_unsaved => :forget)
       end
 
     end

--- a/spec/excel_spec.rb
+++ b/spec/excel_spec.rb
@@ -27,7 +27,6 @@ module RobustExcelOle
 
     after do
       Excel.kill_all
-      #sleep 0.1
       rm_tmp(@dir)
     end
 

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -12,7 +12,7 @@ module RobustExcelOle::SpecHelpers
   end
 
   def rm_tmp(tmpdir)     # :nodoc: #
-    FileUtils.remove_entry_secure(File.dirname(tmpdir))
+    FileUtils.rm_f(File.dirname(tmpdir))
   end
 
   # This method is almost copy of wycats's implementation.


### PR DESCRIPTION
This test failed in my environment because the excel instancens seem to have been stored in reverse order.
So I made the test more robust with respect to ordering. 
I also tried to compress it a little bi.