### PR TITLE
problem to set Excel#calculation when no workbook is visible -- testcase provided

### DIFF
--- a/spec/excel_spec.rb
+++ b/spec/excel_spec.rb
@@ -1501,9 +1501,9 @@ module RobustExcelOle
 
         it "should set calculation mode " do
           expect {       @excel1.calculation = :automatic 
-            }.to change{ @excel1.Calculation 
-          }.from(        XlCalculationManual 
-          ).to(          XlCalculationAutomatic )
+            }.to change{ @excel1.calculation 
+          }.from(        :automatic
+          ).to(          :manual )
         end
       end
 

--- a/spec/excel_spec.rb
+++ b/spec/excel_spec.rb
@@ -1491,6 +1491,21 @@ module RobustExcelOle
         @excel1.CalculateBeforeSave.should == old_calculatebeforesave
       end
 
+      context "with no visible workbook" do
+        before do
+          @excel1 = Excel.create(:calculation => :manual)
+          @book1 = Workbook.open(@simple_file, :visible => false)
+          expect( @book1.Windows(1).Visible ).to be false
+        end
+
+        it "should set calculation mode " do
+          expect {       @excel1.calculation = :automatic 
+            }.to change{ @excel1.Calculation 
+          }.from(        XlCalculationManual 
+          ).to(          XlCalculationAutomatic )
+        end
+      end
+
       it "should do with_calculation with workbook" do
         @excel1 = Excel.new
         book = Workbook.open(@simple_file, :visible => true)


### PR DESCRIPTION
This is a test case that always fails in my environment.
I keep getting this
     WIN32OLERuntimeError:
       (in setting property `CalculateBeforeSave': )
           OLE error code:800A03EC in Microsoft Excel
             Die CalculateBeforeSave-Eigenschaft des Application-Objektes kann nicht festgelegt werden.
           HRESULT error code:0x80020009

Can you confirm this?
Seems to be some kind of Excel bug, but anyhow, I think I need at least a workaround for this.
