### PR TITLE
fix for REO wrongly assuming a wb as blocked when on a network share

### DIFF
--- a/lib/robust_excel_ole/reo_common.rb
+++ b/lib/robust_excel_ole/reo_common.rb
@@ -6,6 +6,16 @@ REO_LOG_FILE  = 'reo.log'.freeze unless Object.const_defined?(:REO_LOG_FILE)
 
 File.delete REO_LOG_FILE rescue nil
 
+unless "any string".respond_to?(:end_with?)
+  class String 
+    def end_with?(*suffixes)
+      suffixes.any? do |suffix|
+        self[-suffix.size .. -1] == suffix
+      end
+    end
+  end
+end
+
 module RobustExcelOle
 
   # @private

--- a/lib/robust_excel_ole/workbook.rb
+++ b/lib/robust_excel_ole/workbook.rb
@@ -265,8 +265,18 @@ module RobustExcelOle
       end
       @ole_workbook = @excel.Workbooks.Item(File.basename(file)) rescue nil
       if @ole_workbook
-        obstructed_by_other_book = (File.basename(file) == File.basename(@ole_workbook.Fullname)) &&
-                                   (General.absolute_path(file) != @ole_workbook.Fullname)
+        obstructed_by_other_book = if (File.basename(file) == File.basename(@ole_workbook.Fullname)) 
+          p1 = General.absolute_path(file) 
+          p2 = @ole_workbook.Fullname
+          is_same_path = if p1[1..1] == ":" and p2[0..1] == '\\\\' # normal path starting with the drive letter and a path in network notation (starting with 2 backslashes)
+            # this is a Workaround for Excel2010 on WinXP: Network drives won't get translated to drive letters. So we'll do it manually:
+            p1_pure_path = p1[2..-1]
+            p2.end_with?(p1_pure_path)  and p2[0, p2.rindex(p1_pure_path)] =~ /^\\\\[\w\d_]+(\\[\w\d_]+)*$/  # e.g. "\\\\server\\folder\\subfolder"
+          else
+            p1 == p2
+          end
+          not is_same_path
+        end
         # if workbook is obstructed by a workbook with same name and different path
         if obstructed_by_other_book
           case options[:if_obstructed]


### PR DESCRIPTION
this bug only seems to occour on WinXP

The fix uses a heuristic to equate the network file format (\\server\dir\subdir) with the drive letter format (L:\dir\subdir).
So it is not always correct. 
But it works for me. ;)