### PR TITLE
ruby 3.0 no longer includes win32api.

### DIFF
--- a/robust_excel_ole.gemspec
+++ b/robust_excel_ole.gemspec
@@ -33,6 +33,7 @@ Gem::Specification.new do |s|
   s.test_files    = `git ls-files -- {test,spec,features}/*`.split("\n")
   s.executables   = `git ls-files -- bin/*`.split("\n").map{ |f| File.basename(f) }
   s.require_paths = ["lib"]
+  s.add_runtime_dependency "win32api", '~> '0.1'
   s.add_runtime_dependency "pry", '>= 0.12.1'
   s.add_runtime_dependency "pry-bond", '>=0.0.1'
   s.add_development_dependency "rspec", '>= 2.6.0'


### PR DESCRIPTION
Add runtime dependency of win32api for ruby 3.0